### PR TITLE
fix: use valid uuid in challenge

### DIFF
--- a/pages/api/presentations/available.ts
+++ b/pages/api/presentations/available.ts
@@ -26,7 +26,7 @@ export default WithApiBearerAuthRequired(async function handler(
       // For demonstation purposes, these values are set from config
       // and from uuid that would be exchanged safely
       domain: config.env_config.domain,
-      challenge: "replay-uuid-" + uuidv4(),
+      challenge: uuidv4(),
     };
     res.status(200).json(query);
   } catch (e) {


### PR DESCRIPTION
UUID is validated, ensure that generated UUID used for `challenge` response element is valid.